### PR TITLE
Missing call to visitors in case no package is defined

### DIFF
--- a/lib/packager/packaging.js
+++ b/lib/packager/packaging.js
@@ -249,6 +249,9 @@ Packaging.prototype.renameOutputFile = function (oldLogicalPath, newLogicalPath)
 Packaging.prototype.build = function () {
     this.callVisitors('onBeforeBuild', []);
     var outputFilesQueue = this.outputFilesQueue;
+    if (outputFilesQueue.length === 0) {
+        this.callVisitors('onReachingBuildEnd', []);
+    }
     while (outputFilesQueue.length > 0) {
         var outFile = outputFilesQueue.shift();
         grunt.verbose.writeln("Creating package " + outFile.logicalPath + "...");


### PR DESCRIPTION
`onReachingBuildEnd` should be called before `onAfterBuild` (on visitors) when the number of packages remaining to be built is 0, so that visitors have the opportunity to define new packages.
When the initial number of packages is 0, `onReachingBuildEnd` was not called. This pull request fixes this issue.

This fix is useful so that `atpackager` can be used without any package defined, relying on `CopyUnpackaged` to create an output file for each source file.
