### PR TITLE
feat #3 keep $constructor/$destructor in skin after normalization

### DIFF
--- a/lib/visitors/ATNormalizeSkin.js
+++ b/lib/visitors/ATNormalizeSkin.js
@@ -36,6 +36,29 @@ var ATNormalizeSkin = function (cfg) {
     this.jsonIndent = cfg.jsonIndent == null ? '    ' : cfg.jsonIndent;
 };
 
+var jsonStringifyKeepFunctions = function (skinClassDef, jsonIndent) {
+    // JSON.stringify removes functions by default. We need to hack it a bit to keep $constructor/$destructor.
+    var $constructor = "function(){}";
+    var $destructor = "function(){}";
+    var jsonStringifyReplacer = function (key, val) {
+        if (typeof val === 'function') {
+            if (key === "$constructor") {
+                $constructor = val.toString();
+            } else if (key === "$destructor") {
+                $destructor = val.toString();
+            }
+        }
+        return val;
+    }
+
+    var stringified = JSON.stringify(skinClassDef, jsonStringifyReplacer, jsonIndent);
+    var addition = ['"$constructor":', $constructor, ",", '"$destructor":', $destructor, ","].join("");
+
+    stringified = stringified.replace('"$prototype"', addition + '"$prototype"');
+
+    return stringified;
+}
+
 ATNormalizeSkin.prototype.onWriteInputFile = function (packaging, outputFile, inputFile) {
     if (!inputFile.isMatch(this.files)) {
         return;
@@ -59,7 +82,7 @@ ATNormalizeSkin.prototype.onWriteInputFile = function (packaging, outputFile, in
         classes : ['aria.widgets.AriaSkinNormalization'],
         oncomplete : function () {
             atContext.aria.widgets.AriaSkinNormalization.normalizeSkin(skinObject);
-            newContent = 'Aria.classDefinition(' + JSON.stringify(skinClassDef, null, jsonIndent) + ');';
+            newContent = 'Aria.classDefinition(' + jsonStringifyKeepFunctions(skinClassDef, jsonIndent) + ');';
         }
     });
     atContext.execTimeouts();


### PR DESCRIPTION
Currently during skin normalization, we use JSON.stringify to convert the skin object into a string. This was fine until the skin definition consisted only of objects with properties.

However, since now skin needs to have $constructor/$destructor in order to load legacy style CSS templates, we need to tweak the skin object serialization to preserve the functions (which are abandoned by default by JSON.stringify).
