### PR TITLE
Adding new Map visitor

### DIFF
--- a/lib/visitors/Map.js
+++ b/lib/visitors/Map.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var grunt = require('../grunt').grunt();
+var path = require('path');
+
+var normalizePath = function (filePath) {
+    return path.normalize(filePath).split(path.sep).join('/'); // only forward slashes for the web
+};
+
+var addToMap = function (map, sourceFile, entry) {
+    if (map.hasOwnProperty(sourceFile)) {
+        grunt.log.error('lMap: conflicting entries in the map for ' + sourceFile.yellow);
+    }
+    map[sourceFile] = entry;
+};
+
+var _Map = function (cfg) {
+    cfg = cfg || {};
+    this.sourceFiles = cfg.sourceFiles || ['**/*']; // source files to take into account in the map
+    this.mapFile = cfg.mapFile || 'map.json'; // file the map should be appended to
+    this.mapFileEncoding = cfg.mapFileEncoding || null; // encoding of the map file
+    this.outputDirectory = cfg.outputDirectory || null; // ouput directory of the map file; if not specified, the global
+                                                        // one is used
+};
+
+_Map.prototype.onAfterBuild = function (packaging) {
+    var map = {};
+    var sourceFiles = packaging.sourceFiles;
+    for (var file in sourceFiles) {
+        var curSourceFile = sourceFiles[file];
+        var outputFile = curSourceFile.outputFile;
+        if (sourceFiles.hasOwnProperty(file) && outputFile) {
+            var normalizedCurSourceFilePath = normalizePath(curSourceFile.logicalPath);
+            var normalizedOutputFilePath = normalizePath(outputFile.logicalPath);
+            addToMap(map, normalizedCurSourceFilePath, normalizedOutputFilePath);
+
+        }
+    }
+    var urlMapString = JSON.stringify(map);
+    var outputMap = path.join(this.outputDirectory || packaging.outputDirectory, this.mapFile);
+    grunt.file.write(outputMap, urlMapString, {
+        encoding : this.mapFileEncoding || grunt.file.defaultEncoding
+    });
+};
+
+module.exports = _Map;


### PR DESCRIPTION
Adds a new visitor which creates a map of the non AT files which have been minified nd hashed.
Sample of map:
{"toto.js": "toto-48fe15e40d5443a4048317394b8bd0ea.js", "js/jquery.js": "js/jquery-54654165165165gfsdg6fsd51g.js"} 

Here is an ATPacager configuration sample using this new visitor:

```
grunt.config.set('atpackager.prod', {
        options : {
            sourceDirectories : ['js'],
            sourceFiles : ['rt/**/*', 'grunt/**/*'],
            outputDirectory : 'output',
            visitors : [{
                type : 'JSMinify',
                cfg : {
                    files : ['**/*.js']
                }
            }, {
                type : 'Hash',
                cfg : {
                    files : ['**/*.js']
                }
            }, {
                type : 'Map',
                cfg : {
                    mapFile : 'map.json',
                    sourceFiles : ['**/*.js'],
                    outputDirectory : 'target'
                }
            }, {
                type : 'CopyUnpackaged',
                cfg : {
                    files : ['**/*.js'],
                    builder : {
                        type : 'Concat'
                    }
                }
            }]
        }
    });
```
