### PR TITLE
Allow null visitors

### DIFF
--- a/lib/packager/packaging.js
+++ b/lib/packager/packaging.js
@@ -302,8 +302,10 @@ Packaging.prototype.createObject = function (cfg, builtinMap) {
  */
 Packaging.prototype.addVisitors = function (visitorsArray) {
     visitorsArray.forEach(function (visitorDesc) {
-        var visitorObject = this.createObject(visitorDesc, this.builtinVisitors);
-        this.visitors.push(visitorObject);
+        if (visitorDesc) {
+            var visitorObject = this.createObject(visitorDesc, this.builtinVisitors);
+            this.visitors.push(visitorObject);
+        }
     }, this);
 };
 


### PR DESCRIPTION
Allowing null visitors can be very useful when the list of visitors can vary dependencing on some parameters.
