### PR TITLE
Adding parameter to exclude packages files excluded from global sourceFiles

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -16,12 +16,14 @@ module.exports = function (grunt) {
 				options: {
 					// sourceDirectories,
 					// outputDirectory,
+					// ATDirectories,
 					// ATBootstrapFile,
 					// ATAppEnvironment,
 					// sourceFiles,
 					// defaultBuilder,
 					// packages,
-					// visitors
+					// visitors,
+					// onlySourceFiles
 				}
 			}
 		}
@@ -121,6 +123,9 @@ Therefore a package definition is made of the following properties:
 * `builder`: the [builder configuration](#builder-configuration) to use to create the output file from the input files.
 * `files`: the list of input files to be processed by the `builder` to create the output file with given `name`
 
+If the list of included files contains some files that are excluded from the global `sourceFiles`, they will be added or not according to the value of option `onlySourceFiles`: if set to true, the extra files required by the package will not be added.
+The default value for `onlySourceFiles` is `false`. It is always advisable to set it to `true` in order to limit the recursive inspection of the source directories in search for files to add.
+
 Note that this list of input `files` will possibly be extended by some specific visitors if needed.
 
 Example of a package definition:
@@ -196,6 +201,7 @@ See [here](./visitors.html) for a detailed list of built-in visitors.
 ## Aria Templates specific
 
 The `ATBootstrapFile` option expects the path of a custom bootstrap file to be used to load Aria Templates. This path can be relative to the `sourceDirectories` configured for the packaging.
+However, it is better to set property `ATDirectories` and avoid to include the directory containing Aria Templates framework from the general sources.
 
 Having such a custom bootstrap file can be necessary in the case of pre-compilation of Atlas templates. Templates pre-compilation can depend on some application environment variables. In order to set the desired environment variables, there are two options:
 

--- a/lib/packager/packaging.js
+++ b/lib/packager/packaging.js
@@ -114,9 +114,9 @@ Packaging.prototype.getAbsolutePath = function (logicalPath) {
  * Add source files specified by patterns.
  * @param {Array} patterns
  */
-Packaging.prototype.addSourceFiles = function (patterns) {
+Packaging.prototype.addSourceFiles = function (patterns, onlyAlreadyAdded) {
     var res = [];
-    var files = this.expandLogicalPaths(patterns);
+    var files = this.expandLogicalPaths(patterns, onlyAlreadyAdded);
     for (var i = 0, l = files.length; i < l; i++) {
         var curFile = files[i];
         res[i] = this.addSourceFile(curFile);
@@ -189,7 +189,7 @@ Packaging.prototype.addOutputFile = function (logicalPath, mustCreate) {
  * Adds a package to this packaging.
  * @param {Object} packageDesc package description
  */
-Packaging.prototype.addPackage = function (packageDesc) {
+Packaging.prototype.addPackage = function (packageDesc, onlyAlreadyAdded) {
     var logicalPath = packageDesc.name;
     var outputFile = this.addOutputFile(logicalPath);
     if (packageDesc.builder) {
@@ -199,7 +199,7 @@ Packaging.prototype.addPackage = function (packageDesc) {
         outputFile.builder = this.createObject(packageDesc.builder, outputFile.builtinBuilders);
     }
     if (packageDesc.files) {
-        var files = this.addSourceFiles(packageDesc.files);
+        var files = this.addSourceFiles(packageDesc.files, onlyAlreadyAdded);
         files.forEach(function (sourceFile) {
             if (sourceFile.outputFile === outputFile) {
                 return;
@@ -314,13 +314,13 @@ Packaging.prototype.addVisitors = function (visitorsArray) {
  * @param {Array} packagesArray array of packages to add. Arrays contained in this array will also be processed as
  * arrays of packages to add.
  */
-Packaging.prototype.addPackages = function (packagesArray) {
+Packaging.prototype.addPackages = function (packagesArray, onlyAlreadyAdded) {
     var self = this;
     var processPackages = function (packageDesc) {
         if (Array.isArray(packageDesc)) {
             packageDesc.forEach(processPackages);
         } else {
-            self.addPackage(packageDesc);
+            self.addPackage(packageDesc, onlyAlreadyAdded);
         }
     };
     processPackages(packagesArray);

--- a/tasks/task-atpackager.js
+++ b/tasks/task-atpackager.js
@@ -32,7 +32,8 @@ module.exports = function (grunt) {
                 ATBootstrapFile : 'aria/bootstrap.js',
                 ATDirectories : [],
                 ATDebug : false,
-                ATAppEnvironment : {}
+                ATAppEnvironment : {},
+                onlySourceFiles : false
             });
 
             currentPackaging.ATBootstrapFile = options.ATBootstrapFile;
@@ -45,7 +46,7 @@ module.exports = function (grunt) {
             currentPackaging.addVisitors(options.visitors);
             currentPackaging.init();
             currentPackaging.addSourceFiles(options.sourceFiles);
-            currentPackaging.addPackages(options.packages);
+            currentPackaging.addPackages(options.packages, options.onlySourceFiles);
             currentPackaging.build();
         } catch (e) {
             grunt.log.error(e);


### PR DESCRIPTION
This commit adds an extra configuration parameter for atpackager: `onlySourceFiles`. If set to true, it will prevent packages definitions from adding files that are globally excluded by the `sourceFiles` option.
The default value for `onlySourceFiles` is `false` for backward compatibility.

The reason for the change is a performance gain in the construction of the packages: looking for files in a list that has already been built when initializing atpackager according to the `sourceFiles` option is much faster than rebuilding the list of available files.
