### PR TITLE
ATNormalizeSkin visitor: should keep js outside of the class definition

### DIFF
--- a/doc/visitors.md
+++ b/doc/visitors.md
@@ -667,8 +667,8 @@ __When__: `onWriteInputFile`
 
 ### Normalization options
 
-* `jsonIndent`, [`String`](http://devdocs.io/javascript/global_objects/string), defaults to _4 spaces_: the indentation string to use.
 * `strict`, [`Boolean`](http://devdocs.io/javascript/global_objects/boolean), defaults to `false`: whether to log actual error messages if there are errors, or to simply log warnings.
+* `outputOptions`, [`Object`](http://devdocs.io/javascript/global_objects/object), defaults to `{beautify: true, quote_keys: true}`: options for the [`UglifyJS' code generator`](http://lisperator.net/uglifyjs/codegen) in charge of generating the skin object.
 
 ## Description
 

--- a/lib/visitors/ATNormalizeSkin.js
+++ b/lib/visitors/ATNormalizeSkin.js
@@ -14,6 +14,10 @@
  */
 
 var grunt = require('../grunt').grunt();
+var uglifyContentProvider = require('../contentProviders/uglifyJS');
+var astToString = require('../uglifyHelpers/astToString.js');
+var jsToAST = require('../uglifyHelpers/jsToAST.js');
+var UglifyJS = require("uglify-js");
 var atInPackaging = require('../ATInPackaging');
 var vm = require('vm');
 var SKIN_CLASSPATH = 'aria.widgets.AriaSkin';
@@ -37,8 +41,8 @@ var evalClassDefinition = function (fileContent, logicalPath) {
 var ATNormalizeSkin = function (cfg) {
     cfg = cfg || {};
     this.files = cfg.files || ['**/*.js'];
-    this.jsonIndent = cfg.jsonIndent == null ? '    ' : cfg.jsonIndent;
     this.strict = cfg.strict;
+    this.outputOptions = cfg.outputOptions || {beautify: true, quote_keys: true};
 };
 
 ATNormalizeSkin.prototype.onWriteInputFile = function (packaging, outputFile, inputFile) {
@@ -51,48 +55,58 @@ ATNormalizeSkin.prototype.onWriteInputFile = function (packaging, outputFile, in
         return;
     }
 
-    var skinClassDef = evalClassDefinition(fileContent, inputFile.logicalPath);
-    if (skinClassDef.$classpath != SKIN_CLASSPATH) {
-        return;
-    }
-    var skinObject = skinClassDef.$prototype.skinObject;
-    var jsonIndent = this.jsonIndent;
     var strict = this.strict;
-
-    var atContext = atInPackaging.getATContext(packaging);
-    var newContent;
-    atContext.Aria.load({
-        classes : ['aria.widgets.AriaSkinNormalization', 'aria.core.Log', 'aria.core.log.SilentArrayAppender'],
-        oncomplete : function () {
-            var appenders = atContext.aria.core.Log.getAppenders();
-            var previousAppenders = appenders.splice(0, appenders.length); // Remove and keep previous appenders
-            var logArrayAppender = appenders[0] = new atContext.aria.core.log.SilentArrayAppender();
-            atContext.aria.widgets.AriaSkinNormalization.normalizeSkin(skinObject);
-            appenders.splice(0, 1); // remove our appender
-            appenders.push.apply(appenders, previousAppenders); // restore previous appenders
-
-            var errors = logArrayAppender.getLogs();
-            var nbErrors = errors.length;
-            logArrayAppender.$dispose();
-            if (nbErrors > 0) {
-                var message = "ATNormalizeSkin: " + nbErrors + " error(s) in " + inputFile.logicalPath.yellow + ":\n" +
-                        errors.map(filterMessage).join("\n");
-                if (strict) {
-                    grunt.log.error(message);
-                } else {
-                    grunt.log.writeln(message);
-                    grunt.log.writeln("Note: to fail the build on a skin normalization error, please set the strict parameter to true in the config of ATNormalizeSkin.");
-                }
+    var ast = uglifyContentProvider.getAST(inputFile, fileContent);
+    var transformer = new UglifyJS.TreeTransformer(function (node) {
+        if (node instanceof UglifyJS.AST_Object && node.properties.length > 0 && node.properties[0].key === "$classpath" && node.properties[0].value.value === SKIN_CLASSPATH) {
+            var skinClassDef = evalClassDefinition(astToString(this.parent(1)), inputFile.logicalPath);
+            if (skinClassDef.$classpath != SKIN_CLASSPATH) {
+                return;
             }
-            newContent = 'Aria.classDefinition(' + JSON.stringify(skinClassDef, null, jsonIndent) + ');';
+
+            var skinObject = skinClassDef.$prototype.skinObject;
+            var atContext = atInPackaging.getATContext(packaging);
+            var newNode = null;
+            atContext.Aria.load({
+                classes : ['aria.widgets.AriaSkinNormalization', 'aria.core.Log', 'aria.core.log.SilentArrayAppender'],
+                oncomplete : function () {
+                    var appenders = atContext.aria.core.Log.getAppenders();
+                    var previousAppenders = appenders.splice(0, appenders.length); // Remove and keep previous appenders
+                    var logArrayAppender = appenders[0] = new atContext.aria.core.log.SilentArrayAppender();
+                    atContext.aria.widgets.AriaSkinNormalization.normalizeSkin(skinObject);
+                    appenders.splice(0, 1); // remove our appender
+                    appenders.push.apply(appenders, previousAppenders); // restore previous appenders
+
+                    var errors = logArrayAppender.getLogs();
+                    var nbErrors = errors.length;
+                    logArrayAppender.$dispose();
+                    if (nbErrors > 0) {
+                        var message = "ATNormalizeSkin: " + nbErrors + " error(s) in " + inputFile.logicalPath.yellow + ":\n" +
+                                errors.map(filterMessage).join("\n");
+                        if (strict) {
+                            grunt.log.error(message);
+                        } else {
+                            grunt.log.writeln(message);
+                            grunt.log.writeln("Note: to fail the build on a skin normalization error, please set the strict parameter to true in the config of ATNormalizeSkin.");
+                        }
+                    }
+                    //Stringify and parse to remove undefined properties in the object, otherwise jsToAST creates "void 0" in the AST.
+                    newNode = jsToAST(JSON.parse(JSON.stringify(skinClassDef)));
+                }
+            });
+            atContext.execTimeouts();
+            if (newNode) {
+                return newNode;
+            }
+            else {
+                grunt.log.error("ATNormalizeSkin: could not normalize " + inputFile.logicalPath.yellow); 
+            }
         }
     });
-    atContext.execTimeouts();
-    if (!newContent) {
-        grunt.log.error("ATNormalizeSkin: could not normalize " + inputFile.logicalPath.yellow);
-        return;
-    }
-    inputFile.setTextContent(newContent);
+
+    var ast2 = ast.transform(transformer);
+    uglifyContentProvider.setAST(inputFile, ast2, this.outputOptions);
+    inputFile.contentProvider = uglifyContentProvider;
 };
 
 module.exports = ATNormalizeSkin;


### PR DESCRIPTION
This version of ATNormalizeSkin works fine, but the code seems over complicated due to the AST <-> JS object transformations.
Any advice to improve it ?
