### PR TITLE
Adding the ATImportPackages visitor.

### DIFF
--- a/doc/visitors.md
+++ b/doc/visitors.md
@@ -69,6 +69,7 @@ Aria Templates (unless specified otherwise, input files filter's default value i
 * [Remove Aria Templates documentation data](#remove-aria-templates-documentation-data-atremovedoc-)
 * [Build an Aria Templates URL Map](#build-an-aria-templates-url-map-aturlmap-)
 * [Normalize Aria Templates skin](#normalize-aria-templates-skin-atnormalizeskin-)
+* [Import Aria Templates packages](#import-aria-templates-packages-atimportpackages-)
 
 
 
@@ -676,6 +677,25 @@ First note that in addition to the given `files` filter, files who don't define 
 
 Then, it normalizes the skin definition using [`aria.widgets.AriaSkinNormalization.normalizeSkin`](http://ariatemplates.com/aria/guide/apps/apidocs/#aria.widgets.AriaSkinNormalization:normalizeSkin:method), replacing the content of the file if done with success, logging an error otherwise.
 
+
+# Import Aria Templates Packages: `ATImportPackages`
+
+Add source files from the given Aria Templates packages. This allows to process each file stored in those packages, and optionally to rebuild the same packages after processing the content.
+
+__When__: `onInit`
+
+## Configuration
+
+* `sourceDirectory`, [`String`](http://devdocs.io/javascript/global_objects/string), defaults to `""` (empty): the directory from which to import the packages.
+* `sourcePackages`, defaults to `['**/*']`: a set of patterns to select the packages to be imported. Passed to the method [`grunt.file.expand`](http://gruntjs.com/api/grunt.file#grunt.file.expand) as `patterns`.
+* `logicalPaths`, defaults to `['**/*']`: a set of patterns to filter the files to be imported inside the selected packages. Passed to the method [`grunt.file.isMatch`](http://gruntjs.com/api/grunt.file#grunt.file.ismatch) as `patterns`.
+* `builder`: can be either `false` or a builder configuration object and defaults to `{type: 'ATMultipart'}`: If this option is not `false`, for each imported package a new package will be created with this builder, and will be associated to the files imported from this package. If this option is set to `false`, the imported files are not associated to any package (so it is possible to repackage them differently).
+
+## Description
+
+The packages to import are selected by the `sourceDirectory` and the `sourcePackages` properties.
+The files to import from those packages are filtered by the `logicalPaths` property.
+For each imported package, if the `builder` property is not `false`, a similar package is configured in the packaging, and associated with the files imported from it.
 
 
 

--- a/lib/visitors/ATImportPackages.js
+++ b/lib/visitors/ATImportPackages.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var grunt = require('../grunt').grunt();
+var path = require('path');
+
+var multiPartHeader = /^(\/\*[\s\S]*?\*\/\s*\r?\n)?\/\/\*\*\*MULTI-PART(\r?\n[^\n]+\n)/;
+var logicalPathHeader = /^\/\/LOGICAL-PATH:([^\s]+)$/;
+
+var parseMultiPart = function (fileContent, filePath, callback) {
+    var multipart = multiPartHeader.exec(fileContent);
+    if (multipart != null) {
+        // it is multipart, we split it; separator is multipart[2]
+        var parts = fileContent.split(multipart[2]), partsLength = parts.length;
+        var logicalPath; // current logical path
+        for (var i = 1; i < partsLength; i += 2) {
+            logicalPath = logicalPathHeader.exec(parts[i]);
+            if (logicalPath != null) {
+                logicalPath = logicalPath[1];
+            }
+            var content = parts[i + 1];
+            if (logicalPath == null || content == null) {
+                grunt.log.error("Multipart file " + filePath.yellow + " contains an invalid entry (logical path: " + logicalPath + ")");
+                continue;
+            }
+            callback(content, logicalPath);
+        }
+    } else {
+        callback(fileContent, filePath);
+    }
+};
+
+var ATImportPackages = function (cfg) {
+    cfg = cfg || {};
+    // setting builder to false allows to repackage differently
+    this.builder = cfg.builder != null ? cfg.builder : {
+        type : "ATMultipart"
+    };
+    this.sourcePackages = cfg.sourcePackages || "**/*";
+    this.sourceDirectory = cfg.sourceDirectory || "";
+    this.logicalPaths = cfg.logicalPaths || "**/*";
+};
+
+ATImportPackages.prototype.onInit = function (packaging) {
+    var expandedFiles = grunt.file.expand({
+        filter : "isFile",
+        cwd : this.sourceDirectory
+    }, this.sourcePackages);
+    var builder = this.builder;
+    var filterLogicalPaths = this.logicalPaths;
+
+    expandedFiles.forEach(function (filePath) {
+        var fileAbsolutePath = path.resolve(path.join(this.sourceDirectory, filePath));
+        var fileContent = grunt.file.read(fileAbsolutePath, {
+            encoding : grunt.file.defaultEncoding
+        });
+        var outputFile = null;
+        if (builder) {
+            outputFile = packaging.addOutputFile(filePath, true);
+            outputFile.builder = packaging.createObject(builder, outputFile.builtinBuilders);
+        }
+        parseMultiPart(fileContent, filePath, function (content, logicalPath) {
+            var isMatch = grunt.file.isMatch(filterLogicalPaths, [logicalPath]);
+            if (!isMatch) {
+                return;
+            }
+            var sourceFile = packaging.addSourceFile(logicalPath, true);
+            sourceFile.setTextContent(content);
+            if (outputFile) {
+                sourceFile.setOutputFile(outputFile);
+            }
+        });
+    }, this);
+};
+
+module.exports = ATImportPackages;


### PR DESCRIPTION
This PR adds a visitor to import Aria Templates packages, allowing to process further each logical path stored in those packages, and optionally to rebuild the same packages after this processing.
