### PR TITLE
Using GeneralTplPreprocessor to compile templates

### DIFF
--- a/lib/contentProviders/ATCompiledTemplate.js
+++ b/lib/contentProviders/ATCompiledTemplate.js
@@ -16,7 +16,15 @@
 var grunt = require('../grunt').grunt();
 var path = require('path');
 var atInPackaging = require('../ATInPackaging');
-var alreadyGeneratedRegExp = /^\s*Aria\.classDefinition\(/;
+
+// Copied from ariatemplates/aria/core/loaders/GeneralTplPreprocessor.js :
+var firstComment = /^\s*\/\*[\s\S]*?\*\//;
+var alreadyGeneratedRegExp = /^\s*(?:var\s+|Aria\.classDefinition\()/;
+var isTemplateCompiled = function (fileContent) {
+    fileContent = fileContent.replace(firstComment, ''); // removes first comment
+    return alreadyGeneratedRegExp.test(fileContent);
+};
+// End of copied code
 
 var classGeneratorsByExtension = {
     'tpl' : 'aria.templates.TplClassGenerator',
@@ -67,24 +75,25 @@ var ATCompiledTemplate = {
         if (fileContent == null) {
             fileContent = inputFile.getTextContent();
         }
-        if (alreadyGeneratedRegExp.test(fileContent)) {
-            // should already be an Aria class
-            return;
-        }
         var compiledTemplate;
-        var atContext = atInPackaging.getATContext(inputFile.packaging);
-        atContext.Aria.load({
-            classes : [classGenerator],
-            oncomplete : function () {
-                var generator = atContext.Aria.getClassRef(classGenerator);
-                generator.parseTemplate(fileContent, true, function (res) {
-                    if (res.classDef) {
-                        compiledTemplate = res.classDef;
-                    }
-                });
-            }
-        });
-        atContext.execTimeouts();
+        if (isTemplateCompiled(fileContent)) {
+            // should already be an Aria class
+            compiledTemplate = fileContent;
+        } else {
+            var atContext = atInPackaging.getATContext(inputFile.packaging);
+            atContext.Aria.load({
+                classes : [classGenerator],
+                oncomplete : function () {
+                    var generator = atContext.Aria.getClassRef(classGenerator);
+                    generator.parseTemplate(fileContent, true, function (res) {
+                        if (res.classDef) {
+                            compiledTemplate = res.classDef;
+                        }
+                    });
+                }
+            });
+            atContext.execTimeouts();
+        }
         inputFile.contentATCompiledTemplate = compiledTemplate;
     }
 };


### PR DESCRIPTION
With Aria Templates >= 1.6, we now use the GeneralTplPreprocessor, from the Aria Templates code, to compile templates.
This avoids duplicating the logic to determine whether a template is already compiled or not, as it changed in Aria Templates, in the following commit:
https://github.com/ariatemplates/ariatemplates/commit/b42d5caee913265da424406ec620865ebe6020e8