### PR TITLE
Removing warnings in ATDependencies for files using CommonJS

### DIFF
--- a/doc/visitors.md
+++ b/doc/visitors.md
@@ -514,6 +514,7 @@ Options:
 
 * `mustExist`, [`Boolean`](http://devdocs.io/javascript/global_objects/boolean), defaults to `true`: whether to be strict or not when finding dependencies. If `true`, determined dependencies must be found in the packaging.
 * `externalDependencies`, [`Array`](http://devdocs.io/javascript/global_objects/array) of [`String`](http://devdocs.io/javascript/global_objects/string), defaults to `[]`: list of paths of dependencies to consider as external, and therefore which do not have to be inside the packaging.
+* `detectCommonJS`, [`Boolean`](http://devdocs.io/javascript/global_objects/boolean), defaults to `true`: whether to enable the detection of the CommonJS syntax. If `true`, `ATDependencies` tries to find any usage of a `require` global function in a file, and if it is used, it will skip the detection of dependencies for this file. If `false`, `ATDependencies` does not try to detect the CommonJS format, which may lead to many warnings in case the file uses the CommonJS syntax, because `ATDependencies` is not designed to work with the CommonJS syntax.
 
 ## Description
 

--- a/lib/visitors/ATDependencies.js
+++ b/lib/visitors/ATDependencies.js
@@ -19,11 +19,18 @@ var atCompiledTemplate = require('../contentProviders/ATCompiledTemplate');
 var atGetDependencies = require('../ATGetDependencies');
 var uglifyContentProvider = require('../contentProviders/uglifyJS');
 
+var isCommonJS = function (ast) {
+    ast.figure_out_scope();
+    var globalRequire = ast.globals.get("require");
+    return !! (globalRequire && globalRequire.undeclared);
+};
+
 var ATDependencies = function (cfg) {
     cfg = cfg || {};
     this.files = cfg.files || ['**/*'];
     this.mustExist = cfg.hasOwnProperty('mustExist') ? cfg.mustExist : true;
     this.externalDependencies = cfg.hasOwnProperty('externalDependencies') ? cfg.externalDependencies : [];
+    this.detectCommonJS = cfg.hasOwnProperty('detectCommonJS') ? cfg.detectCommonJS : true;
 };
 
 ATDependencies.prototype.computeDependencies = function (packaging, inputFile) {
@@ -46,15 +53,22 @@ ATDependencies.prototype.computeDependencies = function (packaging, inputFile) {
     var externalDependencies = this.externalDependencies;
     var ast = uglifyContentProvider.getAST(inputFile, jsStringContent);
     if (ast) {
-        var dependencies = atGetDependencies(ast);
-        dependencies.forEach(function (dependency) {
-            var correspondingFile = packaging.getSourceFile(dependency);
-            if (correspondingFile) {
-                inputFile.addDependency(correspondingFile);
-            } else if (mustExist && !grunt.file.isMatch(externalDependencies, [dependency])) {
-                grunt.log.error(inputFile.logicalPath.yellow + " depends on " + dependency + " which cannot be found.");
-            }
-        });
+        var commonJS = this.detectCommonJS ? isCommonJS(ast) : false;
+        if (commonJS) {
+            // if the CommonJS syntax is used for dependencies,
+            // it is useless to call atGetDependencies
+            grunt.verbose.writeln('ATDependencies: ' + inputFile.logicalPath.yellow + ' uses the CommonJS syntax');
+        } else {
+            var dependencies = atGetDependencies(ast);
+            dependencies.forEach(function (dependency) {
+                var correspondingFile = packaging.getSourceFile(dependency);
+                if (correspondingFile) {
+                    inputFile.addDependency(correspondingFile);
+                } else if (mustExist && !grunt.file.isMatch(externalDependencies, [dependency])) {
+                    grunt.log.error(inputFile.logicalPath.yellow + " depends on " + dependency + " which cannot be found.");
+                }
+            });
+        }
     }
 };
 


### PR DESCRIPTION
If CommonJS is detected, AT dependencies detection will be skipped for the current file.
A file is detected as using the CommonJS syntax if it uses a `require` undeclared global variable.
It is possible to come back to disable the detection of CommonJS with the `detectCommonJS` configuration parameter.