### PR TITLE
Passing screw_ie8:false to uglify-js

### DIFF
--- a/lib/contentProviders/uglifyJS.js
+++ b/lib/contentProviders/uglifyJS.js
@@ -24,7 +24,8 @@ UglifyJS.AST_Node.warn_function = function (message) {
 var defaultOutputOptions = {
     beautify : true,
     ascii_only : true,
-    comments : true
+    comments : true,
+    screw_ie8 : false
 };
 
 var uglifyJSContentProvider = {

--- a/lib/uglifyHelpers/astToString.js
+++ b/lib/uglifyHelpers/astToString.js
@@ -14,6 +14,7 @@
  */
 
 var UglifyJS = require("uglify-js");
+var dontScrewIE8 = require('../uglifyHelpers/dontScrewIE8');
 
 var resetComments = function (ast) {
     var walker = new UglifyJS.TreeWalker(function (node) {
@@ -31,5 +32,5 @@ module.exports = function (ast, outputOptions) {
     if (outputOptions && outputOptions.comments) {
         resetComments(ast);
     }
-    return ast.print_to_string(outputOptions);
+    return ast.print_to_string(dontScrewIE8(outputOptions));
 };

--- a/lib/uglifyHelpers/dontScrewIE8.js
+++ b/lib/uglifyHelpers/dontScrewIE8.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function (config) {
+    if (!config) {
+        return {
+            screw_ie8: false
+        };
+    }
+    if (!("screw_ie8" in config)) {
+        return Object.assign({}, config, {
+            screw_ie8: false
+        });
+    }
+    return config;
+};

--- a/lib/visitors/ATDependencies.js
+++ b/lib/visitors/ATDependencies.js
@@ -20,7 +20,9 @@ var atGetDependencies = require('../ATGetDependencies');
 var uglifyContentProvider = require('../contentProviders/uglifyJS');
 
 var isCommonJS = function (ast) {
-    ast.figure_out_scope();
+    ast.figure_out_scope({
+        screw_ie8: false
+    });
     var globalRequire = ast.globals.get("require");
     return !! (globalRequire && globalRequire.undeclared);
 };

--- a/lib/visitors/CheckGlobals.js
+++ b/lib/visitors/CheckGlobals.js
@@ -64,7 +64,9 @@ CheckGlobals.prototype.onWriteInputFile = function (packaging, outputFile, input
     var ast = uglifyContentProvider.getAST(inputFile);
     var self = this;
     if (ast) {
-        ast.figure_out_scope();
+        ast.figure_out_scope({
+            screw_ie8: false
+        });
         ast.globals.each(function (glob) {
             if (!self._isGlobalAccepted(glob.name)) {
                 grunt.log.error("Forbidden access to global variable " + glob.name.yellow + " in " +

--- a/lib/visitors/JSMinify.js
+++ b/lib/visitors/JSMinify.js
@@ -16,6 +16,7 @@
 var UglifyJS = require('uglify-js');
 var uglifyJSContentProvider = require('../contentProviders/uglifyJS');
 var JSConcat = require('../builders/JSConcat');
+var dontScrewIE8 = require('../uglifyHelpers/dontScrewIE8');
 
 var JSMinify = function (cfg) {
     cfg = cfg || {};
@@ -24,13 +25,14 @@ var JSMinify = function (cfg) {
     this.inputFiles = cfg.inputFiles || ['**/*'];
     this.skipJSConcatParts = "skipJSConcatParts" in cfg ? cfg.skipJSConcatParts : true;
     if (cfg.compress !== false) {
-        this.compressor = UglifyJS.Compressor(cfg.compress || {});
+        this.compressor = UglifyJS.Compressor(dontScrewIE8(cfg.compress || {}));
     }
     if (cfg.mangle !== false) {
         this.mangle = cfg.mangle || {};
     }
     this.outputOptions = cfg.output || {
-        ascii_only : true
+        ascii_only : true,
+        screw_ie8 : false
     };
 };
 
@@ -61,13 +63,17 @@ JSMinify.prototype.onWriteJSOutputFile = function (packaging, outputFile, toBeWr
 
 JSMinify.prototype._compressAST = function (ast) {
     if (this.compressor) {
-        ast.figure_out_scope();
+        ast.figure_out_scope({
+           screw_ie8: false
+        });
         ast = ast.transform(this.compressor);
     }
     if (this.mangle) {
-        ast.figure_out_scope();
+        ast.figure_out_scope({
+            screw_ie8: false
+        });
         ast.compute_char_frequency();
-        ast.mangle_names(this.mangle);
+        ast.mangle_names(dontScrewIE8(this.mangle));
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -11,16 +11,16 @@
   "main": "lib/main.js",
   "dependencies": {
     "murmurhash-js": "1.0.0",
-    "uglify-js": "2.7.4"
+    "uglify-js": "2.7.5"
   },
   "devDependencies": {
     "grunt": "1.0.1",
     "grunt-cli": "1.2.0",
-    "grunt-contrib-jshint": "1.0.0",
+    "grunt-contrib-jshint": "1.1.0",
     "grunt-contrib-copy": "1.0.0",
     "grunt-markdown": "0.7.0",
-    "highlight.js": "9.7.0",
-    "js-yaml": "3.6.1"
+    "highlight.js": "9.8.0",
+    "js-yaml": "3.7.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"


### PR DESCRIPTION
In uglify-js version 2.7.0 and later, the `screw_ie8` option is now `true` by default.
This PR updates dependencies of atpackager and sets that option to false by default when using uglify-js from atpackager.